### PR TITLE
fix print_statisics on wrong unlabeled pid of PRW and others.

### DIFF
--- a/datasets/build.py
+++ b/datasets/build.py
@@ -24,19 +24,29 @@ def print_statistics(dataset):
         "num_images": num_imgs,
         "num_boxes": num_boxes,
     }
-    if len(pid_set) != 1:
+    if dataset.name != "CUHK-SYSU" or dataset.split != "query":
         pid_list = sorted(list(pid_set))
-        unlabeled_pid = pid_list[-1]
-        pid_list = pid_list[:-1]  # remove unlabeled pid
-        num_pids, min_pid, max_pid = len(pid_list), min(pid_list), max(pid_list)
-        statistics.update(
-            {
-                "num_labeled_pids": num_pids,
-                "min_labeled_pid": int(min_pid),
-                "max_labeled_pid": int(max_pid),
-                "unlabeled_pid": int(unlabeled_pid),
-            }
-        )
+        if dataset.split == "query":
+            num_pids, min_pid, max_pid = len(pid_list), min(pid_list), max(pid_list)
+            statistics.update(
+                {
+                    "num_labeled_pids": num_pids,
+                    "min_labeled_pid": int(min_pid),
+                    "max_labeled_pid": int(max_pid),
+                }
+            )
+        else:
+            unlabeled_pid = pid_list[-1]
+            pid_list = pid_list[:-1]  # remove unlabeled pid
+            num_pids, min_pid, max_pid = len(pid_list), min(pid_list), max(pid_list)
+            statistics.update(
+                {
+                    "num_labeled_pids": num_pids,
+                    "min_labeled_pid": int(min_pid),
+                    "max_labeled_pid": int(max_pid),
+                    "unlabeled_pid": int(unlabeled_pid),
+                }
+            )
     print(f"=> {dataset.name}-{dataset.split} loaded:\n" + create_small_table(statistics))
 
 


### PR DESCRIPTION
## In original codes:

**In _CUHK_, the table doesn't show the pid of unlabelled persons, which should not appear in the queries. That's correct.**

|  dataset  |  split  |  num_images  |  num_boxes  |  num_labeled_pids  |  min_labeled_pid  |  max_labeled_pid  |  unlabeled_pid  |
|:---------:|:-------:|:------------:|:-----------:|:------------------:|:-----------------:|:-----------------:|:---------------:|
| CUHK-SYSU |  train  |    11206     |    55272    |        5532        |         1         |       5532        |      5555       |
| CUHK-SYSU | gallery |     6978     |    40871    |        2900        |         1         |       2900        |      5555       |

=> CUHK-SYSU-query loaded:
|  dataset  |  split  |  num_images  |  num_boxes  |
|:---------:|:-------:|:------------:|:-----------:|
| CUHK-SYSU |  query  |     2900     |    2900     |

**While in _PRW_, it shows the last pid as the unlabelled pid in queries:**
=> PRW-train loaded:
|  dataset  |  split  |  num_images  |  num_boxes  |  num_labeled_pids  |  min_labeled_pid  |  max_labeled_pid  |  unlabeled_pid  |
|:---------:|:-------:|:------------:|:-----------:|:------------------:|:-----------------:|:-----------------:|:---------------:|
|    PRW    |  train  |     5704     |    18048    |        483         |         1         |        932        |      5555       |
|    PRW    | gallery |     6112     |    25062    |        544         |         1         |        933        |      5555       |

=> PRW-query loaded:
|  dataset  |  split  |  num_images  |  num_boxes  |  num_labeled_pids  |  min_labeled_pid  |  max_labeled_pid  |  unlabeled_pid  |
|:---------:|:-------:|:------------:|:-----------:|:------------------:|:-----------------:|:-----------------:|:---------------:|
|    PRW    |  query  |     2057     |    2057     |        **449**         |        479        |        **931**        |       **933**       |


## After modification:

=> PRW-train loaded:
|  dataset  |  split  |  num_images  |  num_boxes  |  num_labeled_pids  |  min_labeled_pid  |  max_labeled_pid  |  unlabeled_pid  |
|:---------:|:-------:|:------------:|:-----------:|:------------------:|:-----------------:|:-----------------:|:---------------:|
|    PRW    |  train  |     5704     |    18048    |        483         |         1         |        932        |      5555       |
|    PRW    | gallery |     6112     |    25062    |        544         |         1         |        933        |      5555       |

=> PRW-query loaded:
|  dataset  |  split  |  num_images  |  num_boxes  |  num_labeled_pids  |  min_labeled_pid  |  max_labeled_pid  |
|:---------:|:-------:|:------------:|:-----------:|:------------------:|:-----------------:|:-----------------:|
|    PRW    |  query  |     2057     |    2057     |        **450**         |        479        |        **933**        |


Of course, it doesn't affect the training or test, so only a small problem. Thanks a lot for your nice code.
 