### PR TITLE
fixed the CUDA out of memory

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -72,7 +72,7 @@ def main(args):
         # which equals to inner-products, as features are already L2-normed
         similarities = gallery_feats.mm(query_feat.view(-1, 1)).squeeze()
 
-        visualize_result(gallery_img_path, detections, similarities)
+        visualize_result(gallery_img_path, detections.cpu().numpy(), similarities)
 
 
 if __name__ == "__main__":
@@ -83,4 +83,5 @@ if __name__ == "__main__":
         "opts", nargs=argparse.REMAINDER, help="Modify config options using the command-line"
     )
     args = parser.parse_args()
-    main(args)
+    with torch.no_grad():
+        main(args)


### PR DESCRIPTION
During inference of model,wrapping the model in torch.no_grad() to disable the computation graph.

Befor adding `torch.no_grad()`:
![P40Q L6%_OXQ}3OI{4HRIOU](https://user-images.githubusercontent.com/25292830/145041262-f8b9aa5a-dac0-40bb-988c-2b710f238693.png)

With `torch.no_grad()`:
![1(%J0B6DF4C~S4B%FWHGND8](https://user-images.githubusercontent.com/25292830/145041427-28899f8a-5978-4878-8f7f-0623e7705a72.png)
